### PR TITLE
Fix Makefile not linking ncurses library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ all: hackertyper
 .PHONY: all hackertyper clean install
 
 hackertyper: hackertyper.o
-	cc $(LDFLAGS) -o $@ $^
+	cc -o $@ $^ $(LDFLAGS)
 hackertyper.o: src/hackertyper.c
 	cc -c $(CFLAGS) -o $@ $^
 src/hackertyper.c: src/hackertyper.h


### PR DESCRIPTION
Moving the LDFLAGS to the end of the cc command fixes the ncurses library not being found. Without this fix the source should not even be compilable.