### PR TITLE
Add continious integration with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: c

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: c
+dist: xenial
 
-script: make
+script:
+ - make
+ - make install
 
 jobs:
   include:
-   # Linux build job
-   - name: Linux build
-     dist: xenial
-   # macOS build job
-   - name: macOS build
+   - name: Linux GCC build
+   - name: Linux Clang build
+     compiler: clang
+   - name: macOS GCC build
      os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script: make
 jobs:
   include:
    # Linux build job
-   - name: Build
+   - name: Linux build
      dist: xenial
    # macOS build job
    - name: macOS build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,12 @@
 language: c
+
+script: make
+
+jobs:
+  include:
+   # Linux build job
+   - name: Build
+     dist: xenial
+   # macOS build job
+   - name: macOS build
+     os: osx

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Hackertyper
+# Hackertyper [![Travis Build Status](https://travis-ci.org/Hurricane996/Hackertyper.svg?branch=master)](https://travis-ci.com/Hurricane996/Hackertyper)
 
 Hackertyper is a c program which copies the functionality of http://hackertyper.net, reading characters from a file, and writing said characters to stdout.
 


### PR DESCRIPTION
Tests the Makefile with `make` and `make install` on Ubuntu 16.04 and macOS with GCC and Clang.

For optimal integration with GitHub Travis CI needs to be [enabled](https://github.com/marketplace/travis-ci) on the GitHub Marketplace.